### PR TITLE
Feat/#19 UI place

### DIFF
--- a/HomeTask/App/HomeTaskApp.swift
+++ b/HomeTask/App/HomeTaskApp.swift
@@ -12,10 +12,11 @@ import SwiftData
 struct HomeTaskApp: App {
     let container: ModelContainer
     @State private var homeTaskModel: HomeTaskModel
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     
     init() {
         let container = try! ModelContainer(
-            for: Chore.self
+            for: Chore.self, Place.self
         )
         self.container = container
         self._homeTaskModel = State(

--- a/HomeTask/App/HomeTaskApp.swift
+++ b/HomeTask/App/HomeTaskApp.swift
@@ -25,8 +25,15 @@ struct HomeTaskApp: App {
     }
     var body: some Scene {
         WindowGroup {
-            ChoreView()
+            if hasCompletedOnboarding {
+                ChoreView()
+                    .environment(homeTaskModel)
+            } else {
+                OnboardingView(onComplete: {
+                    hasCompletedOnboarding = true
+                })
                 .environment(homeTaskModel)
+            }
         }
         .modelContainer(container)
     }

--- a/HomeTask/Features/Place/AddPlaceView.swift
+++ b/HomeTask/Features/Place/AddPlaceView.swift
@@ -1,0 +1,171 @@
+//
+//  AddPlaceView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 3/31/26.
+//
+
+import SwiftUI
+import MapKit
+
+struct AddPlaceView: View {
+    @Environment(HomeTaskModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var placeType: PlaceType = .home
+    @State private var placeName = ""
+    @State private var selectedCoordinate: CLLocationCoordinate2D?
+    @State private var selectedAddress = ""
+    @State private var radius: Double = 100
+    @State private var showAddressSearch = false
+
+    private let radiusOptions: [Double] = [100, 200, 300, 500]
+
+    private var canSave: Bool {
+        selectedCoordinate != nil && !placeName.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    placeTypeSection
+                    addressSection
+                    nameSection
+
+                    if selectedCoordinate != nil {
+                        mapPreviewSection
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+
+                    radiusSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+                .padding(.bottom, 80)
+                .animation(.spring(duration: 0.3), value: selectedCoordinate != nil)
+            }
+            .navigationTitle("장소 추가")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("저장") { saveAndDismiss() }
+                        .fontWeight(.semibold)
+                        .disabled(!canSave)
+                }
+            }
+            .sheet(isPresented: $showAddressSearch) {
+                AddressSearchView { item in
+                    selectedAddress = item.name ?? ""
+                    placeName = item.name ?? ""
+                    selectedCoordinate = item.location.coordinate
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections (OnboardingView와 동일)
+
+    private var placeTypeSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("장소 유형", systemImage: "tag")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 10) {
+                ForEach(PlaceType.allCases) { type in
+                    PlaceTypeChip(type: type, isSelected: placeType == type)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.2)) { placeType = type }
+                        }
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var addressSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("주소", systemImage: "magnifyingglass")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            Button { showAddressSearch = true } label: {
+                HStack {
+                    Text(selectedAddress.isEmpty ? "주소를 검색하세요" : selectedAddress)
+                        .foregroundStyle(selectedAddress.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(14)
+                .background(Color(.secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("장소 이름", systemImage: "pencil")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            TextField("예: 우리집, 이마트 홍대점", text: $placeName)
+                .padding(14)
+                .background(Color(.secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private var mapPreviewSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("위치 확인", systemImage: "map")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            if let coordinate = selectedCoordinate {
+                MapPreview(coordinate: coordinate, radius: radius)
+                    .frame(height: 180)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    private var radiusSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("알림 반경", systemImage: "circle.dashed")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                ForEach(radiusOptions, id: \.self) { option in
+                    RadiusChip(label: "\(Int(option))m", isSelected: radius == option)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.2)) { radius = option }
+                        }
+                }
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func saveAndDismiss() {
+        guard let coordinate = selectedCoordinate else { return }
+        model.createPlace(
+            name: placeName.trimmingCharacters(in: .whitespaces),
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude,
+            radius: radius,
+            type: placeType
+        )
+        dismiss()
+    }
+}

--- a/HomeTask/Features/Place/AddressSearchView.swift
+++ b/HomeTask/Features/Place/AddressSearchView.swift
@@ -59,8 +59,8 @@ struct AddressSearchView: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: "장소 또는 주소 입력"
             )
-            .onChange(of: query) { _, newValue in
-                Task { await search(query: newValue) }
+            .task(id: query) {
+                await search(query: query)
             }
             .overlay {
                 if isSearching {

--- a/HomeTask/Features/Place/AddressSearchView.swift
+++ b/HomeTask/Features/Place/AddressSearchView.swift
@@ -1,0 +1,101 @@
+//
+//  AddressSearchView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 3/30/26.
+//
+
+import SwiftUI
+import MapKit
+
+struct AddressSearchView: View {
+    let onSelect: (MKMapItem) -> Void
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var query = ""
+    @State private var results: [MKMapItem] = []
+    @State private var isSearching = false
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                if results.isEmpty && !query.isEmpty && !isSearching {
+                    ContentUnavailableView.search(text: query)
+                } else {
+                    List {
+                        ForEach(results, id: \.self) { item in
+                            Button {
+                                onSelect(item)
+                                dismiss()
+                            } label: {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.name ?? "이름 없음")
+                                        .font(.body)
+                                        .foregroundStyle(.primary)
+                                    
+                                    if let address = item.address {
+                                        Text(address.shortAddress ?? address.fullAddress)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("주소 검색")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") { dismiss() }
+                }
+            }
+            .searchable(
+                text: $query,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "장소 또는 주소 입력"
+            )
+            .onChange(of: query) { _, newValue in
+                Task { await search(query: newValue) }
+            }
+            .overlay {
+                if isSearching {
+                    ProgressView()
+                }
+            }
+        }
+    }
+    
+    // MARK: - Search
+    
+    private func search(query: String) async {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            results = []
+            return
+        }
+        
+        isSearching = true
+        defer { isSearching = false }
+        
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = trimmed
+        request.resultTypes = [.pointOfInterest, .address]
+        request.region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 36.5, longitude: 127.5),
+            latitudinalMeters: 600_000,
+            longitudinalMeters: 600_000
+        )
+        
+        do {
+            let response = try await MKLocalSearch(request: request).start()
+            results = response.mapItems
+        } catch {
+            results = []
+        }
+    }
+}

--- a/HomeTask/Features/Place/OnboardingView.swift
+++ b/HomeTask/Features/Place/OnboardingView.swift
@@ -1,0 +1,299 @@
+//
+//  OnboardingView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 3/30/26.
+//
+
+import SwiftUI
+import MapKit
+
+struct OnboardingView: View {
+    let onComplete: () -> Void
+    
+    @Environment(HomeTaskModel.self) private var model
+    
+    @State private var placeType: PlaceType = .home
+    @State private var placeName = ""
+    @State private var selectedCoordinate: CLLocationCoordinate2D?
+    @State private var selectedAddress = ""
+    @State private var radius: Double = 100
+    @State private var showAddressSearch = false
+    
+    private let radiusOptions: [Double] = [100, 200, 300, 500]
+    
+    private var canSave: Bool {
+        selectedCoordinate != nil && !placeName.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 28) {
+                    headerSection
+                    formSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 32)
+                .padding(.bottom, 120)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            startButton
+        }
+        .sheet(isPresented: $showAddressSearch) {
+            
+            AddressSearchView { item in
+                selectedAddress = item.name ?? ""
+                placeName = item.name ?? ""
+                selectedCoordinate = item.location.coordinate
+            }
+        }
+    }
+    
+    // MARK: - Header
+    
+    private var headerSection: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "mappin.circle.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.tint)
+            
+            Text("첫 장소를 등록해요")
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            Text("집이나 마트 위치를 등록하면\n근처에서 알림을 받을 수 있어요")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+    
+    // MARK: - Form
+    
+    private var formSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            placeTypeSection
+            addressSection
+            nameSection
+            
+            if selectedCoordinate != nil {
+                mapPreviewSection
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+            
+            radiusSection
+        }
+        .animation(.spring(duration: 0.3), value: selectedCoordinate != nil)
+    }
+    
+    private var placeTypeSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("장소 유형", systemImage: "tag")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            
+            HStack(spacing: 10) {
+                ForEach(PlaceType.allCases) { type in
+                    PlaceTypeChip(type: type, isSelected: placeType == type)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.2)) { placeType = type }
+                        }
+                }
+                Spacer()
+            }
+        }
+    }
+    
+    private var addressSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("주소", systemImage: "magnifyingglass")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            
+            Button { showAddressSearch = true } label: {
+                HStack {
+                    Text(selectedAddress.isEmpty ? "주소를 검색하세요" : selectedAddress)
+                        .foregroundStyle(selectedAddress.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(14)
+                .background(Color(.backgroundSecondary))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+    
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("장소 이름", systemImage: "pencil")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            
+            TextField("예: 우리집, 이마트 홍대점", text: $placeName)
+                .padding(14)
+                .background(Color(.backgroundSecondary))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+    
+    private var mapPreviewSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("위치 확인", systemImage: "map")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            
+            if let coordinate = selectedCoordinate {
+                MapPreview(coordinate: coordinate, radius: radius)
+                    .frame(height: 180)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+    
+    private var radiusSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("알림 반경", systemImage: "circle.dashed")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            
+            HStack(spacing: 8) {
+                ForEach(radiusOptions, id: \.self) { option in
+                    RadiusChip(label: "\(Int(option))m", isSelected: radius == option)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.2)) { radius = option }
+                        }
+                }
+                Spacer()
+            }
+        }
+    }
+    
+    // MARK: - Start Button
+    
+    private var startButton: some View {
+        Button {
+            saveAndComplete()
+        } label: {
+            Text("시작하기")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(canSave ? Color.accentColor : Color(.systemGray4))
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .disabled(!canSave)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 8)
+        .background(.clear)
+    }
+    
+    // MARK: - Actions
+    
+    private func saveAndComplete() {
+        guard let coordinate = selectedCoordinate else { return }
+        model.createPlace(
+            name: placeName.trimmingCharacters(in: .whitespaces),
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude,
+            radius: radius,
+            type: placeType
+        )
+        withAnimation { onComplete() }
+    }
+}
+
+// MARK: - PlaceType Chip
+
+struct PlaceTypeChip: View {
+    let type: PlaceType
+    let isSelected: Bool
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: type.icon)
+            Text(type.rawValue)
+                .fontWeight(.medium)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(isSelected ? Color.accentColor.opacity(0.15) : Color(.systemGray6))
+        .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+        .clipShape(Capsule())
+        .overlay(Capsule().strokeBorder(
+            isSelected ? Color.accentColor.opacity(0.5) : .clear, lineWidth: 1
+        ))
+    }
+}
+
+// MARK: - Radius Chip
+
+struct RadiusChip: View {
+    let label: String
+    let isSelected: Bool
+    
+    var body: some View {
+        Text(label)
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(isSelected ? Color.accentColor.opacity(0.15) : Color(.systemGray6))
+            .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+            .clipShape(Capsule())
+            .overlay(Capsule().strokeBorder(
+                isSelected ? Color.accentColor.opacity(0.5) : .clear, lineWidth: 1
+            ))
+    }
+}
+
+// MARK: - Map Preview
+
+struct MapPreview: View {
+    let coordinate: CLLocationCoordinate2D
+    let radius: Double
+    
+    @State private var position: MapCameraPosition = .automatic
+    
+    var body: some View {
+        Map(position: $position) {
+            Annotation("", coordinate: coordinate) {
+                Image(systemName: "mappin.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.red)
+            }
+            MapCircle(center: coordinate, radius: radius)
+                .foregroundStyle(.blue.opacity(0.15))
+                .stroke(.blue.opacity(0.4), lineWidth: 1.5)
+        }
+        .disabled(true)
+        .onAppear {
+            position = makeRegion(radius: radius)
+        }
+        .onChange(of: coordinate.latitude) { _, _ in
+            withAnimation {
+                position = makeRegion(radius: radius)
+            }
+        }
+        .onChange(of: radius) { _, newRadius in
+            withAnimation {
+                position = makeRegion(radius: newRadius)
+            }
+        }
+    }
+    
+    private func makeRegion(radius: Double) -> MapCameraPosition {
+        .region(MKCoordinateRegion(
+            center: coordinate,
+            latitudinalMeters: radius * 6,
+            longitudinalMeters: radius * 6
+        ))
+    }
+}

--- a/HomeTask/Features/Place/OnboardingView.swift
+++ b/HomeTask/Features/Place/OnboardingView.swift
@@ -282,6 +282,11 @@ struct MapPreview: View {
                 position = makeRegion(radius: radius)
             }
         }
+        .onChange(of: coordinate.longitude) { _, _ in
+            withAnimation {
+                position = makeRegion(radius: radius)
+            }
+        }
         .onChange(of: radius) { _, newRadius in
             withAnimation {
                 position = makeRegion(radius: newRadius)

--- a/HomeTask/Features/Place/PlacesListView.swift
+++ b/HomeTask/Features/Place/PlacesListView.swift
@@ -1,0 +1,94 @@
+//
+//  PlacesListView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 3/31/26.
+//
+
+import SwiftUI
+import SwiftData
+
+struct PlacesListView: View {
+    @Environment(HomeTaskModel.self) private var model
+    @Query(sort: \Place.createdAt) private var places: [Place]
+
+    @State private var showAddPlace = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if places.isEmpty {
+                    emptyView
+                } else {
+                    list
+                }
+            }
+            .navigationTitle("장소 관리")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAddPlace = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddPlace) {
+                AddPlaceView()
+            }
+        }
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        List {
+            ForEach(places) { place in
+                PlaceRow(place: place)
+            }
+            .onDelete { indexSet in
+                indexSet.map { places[$0] }.forEach(model.deletePlace)
+            }
+        }
+    }
+
+    // MARK: - Empty
+
+    private var emptyView: some View {
+        ContentUnavailableView(
+            "등록된 장소가 없어요",
+            systemImage: "mappin.slash",
+            description: Text("+ 버튼을 눌러 집이나 마트를 등록해보세요")
+        )
+    }
+}
+
+// MARK: - Place Row
+
+struct PlaceRow: View {
+    let place: Place
+
+    var body: some View {
+        HStack(spacing: 14) {
+            // 아이콘
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.12))
+                    .frame(width: 40, height: 40)
+                Image(systemName: place.type.icon)
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            // 정보
+            VStack(alignment: .leading, spacing: 3) {
+                Text(place.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+                Text("\(place.type.rawValue) · 반경 \(Int(place.radius))m")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/HomeTask/Services/HomeTaskModel.swift
+++ b/HomeTask/Services/HomeTaskModel.swift
@@ -102,4 +102,31 @@ class HomeTaskModel {
             return calendar.date(byAdding: .month, value: 1, to: date) ?? date
         }
     }
+    
+    // MARK: - Place CRUD
+
+    @discardableResult
+    func createPlace(
+        name: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Double = 100,
+        type: PlaceType
+    ) -> Place {
+        let place = Place(
+            name: name,
+            latitude: latitude,
+            longitude: longitude,
+            radius: radius,
+            type: type
+        )
+        modelContext.insert(place)
+        try? modelContext.save()
+        return place
+    }
+
+    func deletePlace(_ place: Place) {
+        modelContext.delete(place)
+        try? modelContext.save()
+    }
 }


### PR DESCRIPTION
## 🚄 작업 내용

- 온보딩 화면 구현 (첫 실행 시 장소 등록 플로우)
- 장소 등록 화면 구현 (주소 검색 + MapKit 지도 미리보기 + 반경 설정)
- 장소 관리 화면 구현 (등록된 장소 목록 + 삭제)

## 💺 주요 코드 설명

### MapKit 주소 검색 정확도 개선
```swift
let request = MKLocalSearch.Request()
request.naturalLanguageQuery = trimmed
request.resultTypes = [.pointOfInterest, .address]
request.region = MKCoordinateRegion(
    center: CLLocationCoordinate2D(latitude: 36.5, longitude: 127.5),
    latitudinalMeters: 600_000,
    longitudinalMeters: 600_000
)
```

`resultTypes`를 `.pointOfInterest`만 사용했을 때 일반 주소 검색 결과가 누락되는 문제가 있었습니다.
`.address`를 함께 추가하고, `region`을 한국 중심으로 설정해 검색 정확도를 개선했습니다.

---

### MapPreview — 주소 변경 시 지도 미업데이트 & 반경 변경 시 화면 리로드

**문제 1 — 주소 변경 시 지도가 업데이트되지 않음**

`coordinate` 변경에 대한 `onChange` 감지 로직이 누락되어 있었습니다.
`CLLocationCoordinate2D`는 `Equatable`을 기본 지원하지 않으므로 `.latitude`를 기준으로 변경을 감지합니다.

**문제 2 — 반경 변경 시 화면 전체 리로드**

커스텀 `init`에서 `@State`를 직접 초기화(`self._position = State(initialValue: ...)`)하는 방식이 원인이었습니다.
부모 뷰에서 `radius`가 바뀔 때마다 `init`이 호출되면서 SwiftUI가 뷰를 재생성했습니다.

**해결 — 커스텀 `init` 제거 후 `onAppear` + `onChange` 패턴으로 전환**
```swift
// Before
init(coordinate: CLLocationCoordinate2D, radius: Double) {
    self._position = State(initialValue: .region(...)) // ← 리로드 원인
}

// After
@State private var position: MapCameraPosition = .automatic

.onAppear {
    position = makeRegion(radius: radius)
}
.onChange(of: coordinate.latitude) { _, _ in      // 주소 변경 감지
    withAnimation { position = makeRegion(radius: radius) }
}
.onChange(of: radius) { _, newRadius in           // 반경 변경 감지
    withAnimation { position = makeRegion(radius: newRadius) }
}
```

## 🛤️ 구현화면

|   온보딩(라이트)   |  온보딩(다크)    |
| :----------: | :----------: |
| <img src="https://github.com/user-attachments/assets/097bf894-8a71-4437-86a4-2badcd4e9679" width="250"> | <img src="https://github.com/user-attachments/assets/6901a7d0-e6be-4b9c-9c77-14c100ec6589" width="250"> |


## 🚂 연결된 이슈

- Closes #19

## 🚃 기타 더 이야기해볼 점

- `PlaceTypeChip`, `RadiusChip`, `MapPreview` 컴포넌트는 `OnboardingView`와 `AddPlaceView`에서 공용으로 사용하고 있습니다. 추후 별도 파일로 분리 여부 논의가 필요할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 첫 실행 온보딩 화면 추가 및 완료 상태 저장
  * 장소 등록 화면 추가(타입 선택, 주소 검색, 이름, 반경 설정)
  * 주소 검색 UI(실시간 검색, 선택 기능) 추가
  * 지도 미리보기 및 선택한 위치/반경 시각화 추가
  * 장소 목록 조회·삭제 기능 및 개별 장소 행 표시 추가
  * 장소 생성·삭제 기능 백엔드 연동 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->