### PR TITLE
Feat/#18 service geofence

### DIFF
--- a/HomeTask/App/HomeTaskApp.swift
+++ b/HomeTask/App/HomeTaskApp.swift
@@ -28,6 +28,9 @@ struct HomeTaskApp: App {
             if hasCompletedOnboarding {
                 ChoreView()
                     .environment(homeTaskModel)
+                    .task {
+                        await homeTaskModel.startGeofencing()
+                    }
             } else {
                 OnboardingView(onComplete: {
                     hasCompletedOnboarding = true

--- a/HomeTask/Info.plist
+++ b/HomeTask/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+</dict>
+</plist>

--- a/HomeTask/Models/Place.swift
+++ b/HomeTask/Models/Place.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 @Model
 final class Place {
+    var id: UUID = UUID()
     var name: String
     var latitude: Double
     var longitude: Double

--- a/HomeTask/Services/GeofenceManager.swift
+++ b/HomeTask/Services/GeofenceManager.swift
@@ -1,0 +1,168 @@
+//
+//  GeofenceManager.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/6/26.
+//
+
+import CoreLocation
+import Foundation
+import Observation
+import UserNotifications
+
+@Observable
+final class GeofenceManager: NSObject {
+
+    var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    var isMonitoring: Bool = false
+
+    private var monitor: CLMonitor?
+    private let locationManager = CLLocationManager()
+    private var monitorTask: Task<Void, Never>?
+
+    override init() {
+        super.init()
+        locationManager.delegate = self
+        authorizationStatus = locationManager.authorizationStatus
+    }
+
+    func requestAlwaysAuthorization() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    func startMonitoring(places: [Place]) async {
+        await stopMonitoring()
+
+        let m = await CLMonitor("HomeTaskGeofenceMonitor")
+        self.monitor = m
+
+        for identifier in await m.identifiers {
+            await m.remove(identifier)
+        }
+
+        for place in places {
+            let condition = CLMonitor.CircularGeographicCondition(
+                center: CLLocationCoordinate2D(
+                    latitude: place.latitude,
+                    longitude: place.longitude
+                ),
+                radius: place.radius
+            )
+            await m.add(condition, identifier: place.id.uuidString)
+        }
+
+        await MainActor.run { isMonitoring = true }
+        startEventLoop(monitor: m, places: places)
+    }
+
+    func stopMonitoring() async {
+        monitorTask?.cancel()
+        monitorTask = nil
+
+        if let m = monitor {
+            for identifier in await m.identifiers {
+                await m.remove(identifier)
+            }
+            monitor = nil
+        }
+
+        await MainActor.run { isMonitoring = false }
+    }
+
+    func updateMonitoring(for place: Place) async {
+        guard let m = monitor else { return }
+        let condition = CLMonitor.CircularGeographicCondition(
+            center: CLLocationCoordinate2D(latitude: place.latitude, longitude: place.longitude),
+            radius: place.radius
+        )
+        await m.add(condition, identifier: place.id.uuidString)
+    }
+
+    func removeMonitoring(for place: Place) async {
+        guard let m = monitor else { return }
+        await m.remove(place.id.uuidString)
+    }
+}
+
+private extension GeofenceManager {
+
+    func startEventLoop(monitor: CLMonitor, places: [Place]) {
+        monitorTask = Task { [weak self] in
+            do {
+                for try await event in await monitor.events {
+                    guard let self else { return }
+                    await self.handleGeofenceEvent(event, places: places)
+                }
+            } catch {
+                print("[GeofenceManager] 이벤트 루프 오류: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    func handleGeofenceEvent(_ event: CLMonitor.Event, places: [Place]) async {
+        guard let place = places.first(where: { $0.id.uuidString == event.identifier }) else { return }
+
+        switch event.state {
+        case .satisfied:
+            handleArrival(at: place)
+        case .unsatisfied:
+            handleDeparture(from: place)
+        default:
+            break
+        }
+    }
+}
+
+private extension GeofenceManager {
+
+    @MainActor
+    func handleArrival(at place: Place) {
+        switch place.type {
+        case .home:
+            // liveActivityManager?.startTodayActivity(chores: todayChores)
+            break
+        case .mart:
+            sendShoppingNotification(for: place)
+        }
+    }
+
+    @MainActor
+    func handleDeparture(from place: Place) {
+        switch place.type {
+        case .home:
+            break
+        case .mart:
+            break
+        }
+    }
+}
+
+private extension GeofenceManager {
+
+    func sendShoppingNotification(for place: Place) {
+        let content = UNMutableNotificationContent()
+        content.title = "🛒 장보기 알림"
+        content.body = "'\(place.name)'에 도착했어요! 장볼 목록을 확인해보세요."
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "geofence-shopping-\(place.id.uuidString)",
+            content: content,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                print("[GeofenceManager] 알림 전송 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+extension GeofenceManager: CLLocationManagerDelegate {
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+    }
+}

--- a/HomeTask/Services/GeofenceManager.swift
+++ b/HomeTask/Services/GeofenceManager.swift
@@ -13,23 +13,44 @@ import UserNotifications
 @Observable
 final class GeofenceManager: NSObject {
 
+    // MARK: - PlaceInfo
+    fileprivate struct PlaceInfo: Sendable {
+        let name: String
+        let type: PlaceType
+    }
+
+    // MARK: - 상태 (View에서 관찰 가능)
     var authorizationStatus: CLAuthorizationStatus = .notDetermined
     var isMonitoring: Bool = false
 
+    // MARK: - Private
     private var monitor: CLMonitor?
     private let locationManager = CLLocationManager()
     private var monitorTask: Task<Void, Never>?
+    private var monitoredPlaces: [String: PlaceInfo] = [:]
 
+    // MARK: - Init
     override init() {
         super.init()
         locationManager.delegate = self
         authorizationStatus = locationManager.authorizationStatus
     }
 
+    // MARK: - 위치 권한 요청
     func requestAlwaysAuthorization() {
         locationManager.requestAlwaysAuthorization()
     }
 
+    // MARK: - 알림 권한 요청
+    func requestNotificationAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
+            if let error {
+                print("[GeofenceManager] 알림 권한 요청 오류: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - 모니터링 시작
     func startMonitoring(places: [Place]) async {
         await stopMonitoring()
 
@@ -40,6 +61,7 @@ final class GeofenceManager: NSObject {
             await m.remove(identifier)
         }
 
+        var placesDict: [String: PlaceInfo] = [:]
         for place in places {
             let condition = CLMonitor.CircularGeographicCondition(
                 center: CLLocationCoordinate2D(
@@ -49,12 +71,18 @@ final class GeofenceManager: NSObject {
                 radius: place.radius
             )
             await m.add(condition, identifier: place.id.uuidString)
+            placesDict[place.id.uuidString] = PlaceInfo(name: place.name, type: place.type)
         }
 
-        await MainActor.run { isMonitoring = true }
-        startEventLoop(monitor: m, places: places)
+        await MainActor.run {
+            self.monitoredPlaces = placesDict
+            self.isMonitoring = true
+        }
+
+        startEventLoop(monitor: m)
     }
 
+    // MARK: - 모니터링 종료
     func stopMonitoring() async {
         monitorTask?.cancel()
         monitorTask = nil
@@ -66,9 +94,13 @@ final class GeofenceManager: NSObject {
             monitor = nil
         }
 
-        await MainActor.run { isMonitoring = false }
+        await MainActor.run {
+            monitoredPlaces = [:]
+            isMonitoring = false
+        }
     }
 
+    // MARK: - 단일 장소 업데이트 (장소 추가/편집 시 호출)
     func updateMonitoring(for place: Place) async {
         guard let m = monitor else { return }
         let condition = CLMonitor.CircularGeographicCondition(
@@ -76,22 +108,29 @@ final class GeofenceManager: NSObject {
             radius: place.radius
         )
         await m.add(condition, identifier: place.id.uuidString)
+        await MainActor.run {
+            monitoredPlaces[place.id.uuidString] = PlaceInfo(name: place.name, type: place.type)
+        }
     }
 
+    // MARK: - 단일 장소 제거
     func removeMonitoring(for place: Place) async {
+        let identifier = place.id.uuidString
         guard let m = monitor else { return }
-        await m.remove(place.id.uuidString)
+        await m.remove(identifier)
+        _ = await MainActor.run { monitoredPlaces.removeValue(forKey: identifier) }
     }
 }
 
+// MARK: - 이벤트 루프
 private extension GeofenceManager {
 
-    func startEventLoop(monitor: CLMonitor, places: [Place]) {
+    func startEventLoop(monitor: CLMonitor) {
         monitorTask = Task { [weak self] in
             do {
                 for try await event in await monitor.events {
                     guard let self else { return }
-                    await self.handleGeofenceEvent(event, places: places)
+                    await self.handleGeofenceEvent(event)
                 }
             } catch {
                 print("[GeofenceManager] 이벤트 루프 오류: \(error.localizedDescription)")
@@ -100,54 +139,58 @@ private extension GeofenceManager {
     }
 
     @MainActor
-    func handleGeofenceEvent(_ event: CLMonitor.Event, places: [Place]) async {
-        guard let place = places.first(where: { $0.id.uuidString == event.identifier }) else { return }
+    func handleGeofenceEvent(_ event: CLMonitor.Event) async {
+        guard let info = monitoredPlaces[event.identifier] else { return }
 
         switch event.state {
         case .satisfied:
-            handleArrival(at: place)
+            handleArrival(identifier: event.identifier, info: info)
         case .unsatisfied:
-            handleDeparture(from: place)
+            handleDeparture(info: info)
         default:
             break
         }
     }
 }
 
+// MARK: - 도착/이탈 처리
 private extension GeofenceManager {
 
     @MainActor
-    func handleArrival(at place: Place) {
-        switch place.type {
+    func handleArrival(identifier: String, info: PlaceInfo) {
+        switch info.type {
         case .home:
-            // liveActivityManager?.startTodayActivity(chores: todayChores)
-            break
+            print("[GeofenceManager] 🏠 집 도착 감지")
+            // TODO: - 라이브엑티비티 실행
+
         case .mart:
-            sendShoppingNotification(for: place)
+            print("[GeofenceManager] 🛒 마트 도착 감지 → 장보기 알림 전송")
+            sendShoppingNotification(identifier: identifier, name: info.name)
         }
     }
 
     @MainActor
-    func handleDeparture(from place: Place) {
-        switch place.type {
+    func handleDeparture(info: PlaceInfo) {
+        switch info.type {
         case .home:
-            break
+            print("[GeofenceManager] 🏠 집 이탈 감지")
         case .mart:
-            break
+            print("[GeofenceManager] 🛒 마트 이탈 감지")
         }
     }
 }
 
+// MARK: - 장보기 로컬 알림
 private extension GeofenceManager {
 
-    func sendShoppingNotification(for place: Place) {
+    func sendShoppingNotification(identifier: String, name: String) {
         let content = UNMutableNotificationContent()
         content.title = "🛒 장보기 알림"
-        content.body = "'\(place.name)'에 도착했어요! 장볼 목록을 확인해보세요."
+        content.body = "'\(name)'에 도착했어요! 장볼 목록을 확인해보세요."
         content.sound = .default
 
         let request = UNNotificationRequest(
-            identifier: "geofence-shopping-\(place.id.uuidString)",
+            identifier: "geofence-shopping-\(identifier)",
             content: content,
             trigger: nil
         )
@@ -160,6 +203,7 @@ private extension GeofenceManager {
     }
 }
 
+// MARK: - CLLocationManagerDelegate
 extension GeofenceManager: CLLocationManagerDelegate {
 
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {

--- a/HomeTask/Services/HomeTaskModel.swift
+++ b/HomeTask/Services/HomeTaskModel.swift
@@ -11,10 +11,18 @@ import SwiftData
 @Observable
 class HomeTaskModel {
     private let modelContext: ModelContext
+    let geofenceManager = GeofenceManager()
     
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
+    
+    func startGeofencing() async {
+           geofenceManager.requestAlwaysAuthorization()
+           let descriptor = FetchDescriptor<Place>()
+           let places = (try? modelContext.fetch(descriptor)) ?? []
+           await geofenceManager.startMonitoring(places: places)
+       }
     
     // MARK: - Chore CRUD
     
@@ -122,10 +130,12 @@ class HomeTaskModel {
         )
         modelContext.insert(place)
         try? modelContext.save()
+        Task { await geofenceManager.updateMonitoring(for: place) }
         return place
     }
 
     func deletePlace(_ place: Place) {
+        Task { await geofenceManager.removeMonitoring(for: place) } 
         modelContext.delete(place)
         try? modelContext.save()
     }

--- a/HomeTask/Services/HomeTaskModel.swift
+++ b/HomeTask/Services/HomeTaskModel.swift
@@ -18,11 +18,12 @@ class HomeTaskModel {
     }
     
     func startGeofencing() async {
-           geofenceManager.requestAlwaysAuthorization()
-           let descriptor = FetchDescriptor<Place>()
-           let places = (try? modelContext.fetch(descriptor)) ?? []
-           await geofenceManager.startMonitoring(places: places)
-       }
+        geofenceManager.requestAlwaysAuthorization()
+        geofenceManager.requestNotificationAuthorization()
+        let descriptor = FetchDescriptor<Place>()
+        let places = (try? modelContext.fetch(descriptor)) ?? []
+        await geofenceManager.startMonitoring(places: places)
+    }
     
     // MARK: - Chore CRUD
     
@@ -112,7 +113,7 @@ class HomeTaskModel {
     }
     
     // MARK: - Place CRUD
-
+    
     @discardableResult
     func createPlace(
         name: String,
@@ -133,9 +134,9 @@ class HomeTaskModel {
         Task { await geofenceManager.updateMonitoring(for: place) }
         return place
     }
-
+    
     func deletePlace(_ place: Place) {
-        Task { await geofenceManager.removeMonitoring(for: place) } 
+        Task { await geofenceManager.removeMonitoring(for: place)}
         modelContext.delete(place)
         try? modelContext.save()
     }


### PR DESCRIPTION
## 🚄 작업 내용

- `GeofenceManager` 서비스 구현 (CLMonitor iOS 17+ 기반 지오펜스 관리)
- 집 도착 이벤트 감지 → LiveActivityManager 연동 stub
- 마트 도착 이벤트 감지 → 로컬 푸시 알림 전송
- 위치 권한 요청 (Always) 처리 및 권한 상태 관찰
- `HomeTaskModel`에 `GeofenceManager` 통합 — Place CRUD 시 지오펜스 자동 동기화
- Info.plist `NSLocationWhenInUseUsageDescription` / `NSLocationAlwaysAndWhenInUseUsageDescription` 추가
- Background Modes → Location updates 활성화

## 💺 주요 코드 설명

**CLMonitor actor 기반 비동기 이벤트 루프**

```swift
func startEventLoop(monitor: CLMonitor, places: [Place]) {
    monitorTask = Task { [weak self] in
        for try await event in await monitor.events {
            guard let self else { return }
            await self.handleGeofenceEvent(event, places: places)
        }
    }
}
```

`CLMonitor`는 `actor`이기 때문에 모든 접근에 `await`가 필요합니다. `for try await`을 사용해 이벤트가 올 때마다 자동으로 깨어나는 구조로, 앱이 백그라운드에 있어도 지오펜스 진입/이탈을 감지합니다. `[weak self]`로 GeofenceManager 해제 시 Task도 함께 정리됩니다.

**`handleGeofenceEvent`에 `async` 명시**

```swift
// Before
@MainActor
func handleGeofenceEvent(_ event: CLMonitor.Event, places: [Place]) { }

// After
@MainActor
func handleGeofenceEvent(_ event: CLMonitor.Event, places: [Place]) async { }
```

`@MainActor`만으로는 컴파일러가 `await` 호출을 인식하지 못해 `No 'async' operations occur within 'await' expression` 경고가 발생했습니다. `async`를 명시해 해결했습니다.

**HomeTaskModel 연동 — Place CRUD 시 자동 지오펜스 동기화**

```swift
func createPlace(...) -> Place {
    let place = Place(...)
    modelContext.insert(place)
    try? modelContext.save()
    Task { await geofenceManager.updateMonitoring(for: place) }
    return place
}

func deletePlace(_ place: Place) {
    Task { await geofenceManager.removeMonitoring(for: place) }
    modelContext.delete(place)
    try? modelContext.save()
}
```

Place 추가/삭제 시점에 지오펜스도 자동으로 동기화되어 별도 호출 없이 항상 최신 상태를 유지합니다.

## 🛤️ 구현화면

서비스 레이어 작업으로 별도 UI 없음. 추후 탭바 구현 후 실기기 테스트 예정.

## 🚂 연결된 이슈

- Closes #18 

## 🚃 기타 더 이야기해볼 점

- `Place` 모델에 `var id: UUID = UUID()` 추가가 전제되어 있습니다. (`CLMonitor` identifier로 UUID 사용)
- `GeofenceManager`의 `startMonitoring`은 앱 시작 시 `HomeTaskApp`의 `.task`에서 한 번 호출되며, 이후 변경사항은 `updateMonitoring` / `removeMonitoring`으로 개별 처리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 지오펜싱 기반 위치 추적 및 즉시 로컬 알림 지원 — 설정한 장소(예: 마트) 도착 시 알림 수신.
  * 백그라운드 위치 모니터링 활성화 — 앱이 백그라운드여도 위치 기반 기능 작동.
  * 온보딩 완료 시 앱 실행 시 자동으로 위치 모니터링 시작.
  * 장소 생성/삭제 시 모니터링이 즉시 업데이트되어 변경이 즉시 반영됩니다.
* **품질 개선**
  * 장소 식별 안정성 향상으로 지오펜스 관리가 더 신뢰성 있게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->