### PR TITLE
Feat/#26 UI tabbar

### DIFF
--- a/HomeTask/App/HomeTaskApp.swift
+++ b/HomeTask/App/HomeTaskApp.swift
@@ -26,7 +26,7 @@ struct HomeTaskApp: App {
     var body: some Scene {
         WindowGroup {
             if hasCompletedOnboarding {
-                ChoreView()
+                MainTabView()
                     .environment(homeTaskModel)
                     .task {
                         await homeTaskModel.startGeofencing()

--- a/HomeTask/Features/Chore/AddChoreView.swift
+++ b/HomeTask/Features/Chore/AddChoreView.swift
@@ -22,7 +22,7 @@ struct AddChoreView: View {
     @State private var repeatInterval: RepeatInterval = .weekly
     
     var body: some View {
-        NavigationStack {
+        VStack {
             Form {
                 titleSection
                 categorySection

--- a/HomeTask/Features/Chore/ChoreView.swift
+++ b/HomeTask/Features/Chore/ChoreView.swift
@@ -22,7 +22,7 @@ struct ChoreView: View {
     }
     
     var body: some View {
-        NavigationStack {
+        VStack {
             List {
                 if !chores.isEmpty {
                     ProgressView(value: Double(completedChores.count),

--- a/HomeTask/Features/Place/AddPlaceView.swift
+++ b/HomeTask/Features/Place/AddPlaceView.swift
@@ -61,7 +61,7 @@ struct AddPlaceView: View {
                 AddressSearchView { item in
                     selectedAddress = item.name ?? ""
                     placeName = item.name ?? ""
-                    selectedCoordinate = item.location.coordinate
+                    selectedCoordinate = item.placemark.location?.coordinate
                 }
             }
         }

--- a/HomeTask/Features/Place/AddressSearchView.swift
+++ b/HomeTask/Features/Place/AddressSearchView.swift
@@ -33,11 +33,25 @@ struct AddressSearchView: View {
                                     Text(item.name ?? "이름 없음")
                                         .font(.body)
                                         .foregroundStyle(.primary)
-                                    
-                                    if let address = item.address {
-                                        Text(address.shortAddress ?? address.fullAddress)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
+
+                                    if #available(iOS 26.0, *) {
+                                        if let address = item.address {
+                                            Text(address.shortAddress ?? address.fullAddress)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    } else {
+                                        let parts = [
+                                            item.placemark.thoroughfare,
+                                            item.placemark.locality,
+                                            item.placemark.administrativeArea
+                                        ].compactMap { $0 }
+
+                                        if !parts.isEmpty {
+                                            Text(parts.joined(separator: ", "))
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
                                     }
                                 }
                                 .padding(.vertical, 4)

--- a/HomeTask/Features/Place/OnboardingView.swift
+++ b/HomeTask/Features/Place/OnboardingView.swift
@@ -46,7 +46,7 @@ struct OnboardingView: View {
             AddressSearchView { item in
                 selectedAddress = item.name ?? ""
                 placeName = item.name ?? ""
-                selectedCoordinate = item.location.coordinate
+                selectedCoordinate = item.placemark.location?.coordinate
             }
         }
     }

--- a/HomeTask/Features/Place/PlacesListView.swift
+++ b/HomeTask/Features/Place/PlacesListView.swift
@@ -15,7 +15,7 @@ struct PlacesListView: View {
     @State private var showAddPlace = false
 
     var body: some View {
-        NavigationStack {
+        VStack {
             Group {
                 if places.isEmpty {
                     emptyView
@@ -70,7 +70,6 @@ struct PlaceRow: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            // 아이콘
             ZStack {
                 Circle()
                     .fill(Color.accentColor.opacity(0.12))
@@ -79,7 +78,6 @@ struct PlaceRow: View {
                     .foregroundStyle(Color.accentColor)
             }
 
-            // 정보
             VStack(alignment: .leading, spacing: 3) {
                 Text(place.name)
                     .font(.body)

--- a/HomeTask/Features/Point/PointView.swift
+++ b/HomeTask/Features/Point/PointView.swift
@@ -1,0 +1,18 @@
+//
+//  PointView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/7/26.
+//
+
+import SwiftUI
+
+struct PointView: View {
+    var body: some View {
+        Text("PointView")
+    }
+}
+
+#Preview {
+    PointView()
+}

--- a/HomeTask/Features/Setting/SettingView.swift
+++ b/HomeTask/Features/Setting/SettingView.swift
@@ -1,0 +1,15 @@
+//
+//  SettingsView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/7/26.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("SettingsView")
+    }
+}
+

--- a/HomeTask/Features/Shopping/ShoppingView.swift
+++ b/HomeTask/Features/Shopping/ShoppingView.swift
@@ -1,0 +1,18 @@
+//
+//  ShoppingView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/7/26.
+//
+
+import SwiftUI
+
+struct ShoppingView: View {
+    var body: some View {
+        Text("ShoppingView")
+    }
+}
+
+#Preview {
+    ShoppingView()
+}

--- a/HomeTask/Features/Tab/AppTab.swift
+++ b/HomeTask/Features/Tab/AppTab.swift
@@ -1,0 +1,35 @@
+//
+//  AppTab.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/7/26.
+//
+
+import Foundation
+
+enum AppTab: String, CaseIterable, Hashable {
+    case chore
+    case shopping
+    case point
+    case settings
+}
+
+extension AppTab {
+    var title: String {
+        switch self {
+        case .chore:    return "집안일"
+        case .shopping: return "쇼핑"
+        case .point:    return "포인트"
+        case .settings: return "설정"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .chore:    return "checklist"
+        case .shopping: return "cart.fill"
+        case .point:    return "star.fill"
+        case .settings: return "gearshape.fill"
+        }
+    }
+}

--- a/HomeTask/Features/Tab/MainTabView.swift
+++ b/HomeTask/Features/Tab/MainTabView.swift
@@ -1,0 +1,44 @@
+//
+//  MainTabView.swift
+//  HomeTask
+//
+//  Created by 어재선 on 4/7/26.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    @State private var selectedTab: AppTab = .chore
+    @State private var chorePath = NavigationPath()
+    @State private var shoppingPath = NavigationPath()
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            ForEach(AppTab.allCases, id: \.self) { tab in
+                tabContent(for: tab)
+                    .tabItem { Label(tab.title, systemImage: tab.icon) }
+                    .tag(tab)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tabContent(for tab: AppTab) -> some View {
+        switch tab {
+        case .chore:
+            NavigationStack(path: $chorePath) {
+                ChoreView()
+            }
+        case .shopping:
+            NavigationStack(path: $shoppingPath) {
+                ShoppingView()
+            }
+        case .point:
+            PointView()
+        case .settings:
+            NavigationStack {
+                SettingsView()
+            }
+        }
+    }
+}

--- a/HomeTask/Services/GeofenceManager.swift
+++ b/HomeTask/Services/GeofenceManager.swift
@@ -34,9 +34,17 @@ final class GeofenceManager: NSObject {
         super.init()
         locationManager.delegate = self
         authorizationStatus = locationManager.authorizationStatus
+        
+        if locationManager.authorizationStatus == .authorizedWhenInUse {
+               locationManager.requestAlwaysAuthorization()
+           }
     }
 
     // MARK: - 위치 권한 요청
+    func requestWhenInUseAuthorization() {
+        locationManager.requestWhenInUseAuthorization()
+    }
+    
     func requestAlwaysAuthorization() {
         locationManager.requestAlwaysAuthorization()
     }
@@ -208,5 +216,9 @@ extension GeofenceManager: CLLocationManagerDelegate {
 
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         authorizationStatus = manager.authorizationStatus
+        
+        if manager.authorizationStatus == .authorizedWhenInUse {
+               locationManager.requestAlwaysAuthorization()
+           }
     }
 }

--- a/HomeTask/Services/HomeTaskModel.swift
+++ b/HomeTask/Services/HomeTaskModel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import CoreLocation
 
 @Observable
 class HomeTaskModel {
@@ -18,8 +19,17 @@ class HomeTaskModel {
     }
     
     func startGeofencing() async {
-        geofenceManager.requestAlwaysAuthorization()
+        switch geofenceManager.authorizationStatus {
+        case .notDetermined:
+            geofenceManager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse:
+            geofenceManager.requestAlwaysAuthorization()
+        default:
+            break
+        }
+
         geofenceManager.requestNotificationAuthorization()
+
         let descriptor = FetchDescriptor<Place>()
         let places = (try? modelContext.fetch(descriptor)) ?? []
         await geofenceManager.startMonitoring(places: places)


### PR DESCRIPTION
## 🚄 작업 내용

- `AppTab` enum 정의 (chore / shopping / point / settings, `CaseIterable` + `Hashable`)
- `MainTabView` 구현 — 탭별 `NavigationStack` 분리, `NavigationPath`로 탭 전환 시 상태 유지
- `HomeTaskApp.swift` 루트 뷰를 `ChoreView` → `MainTabView`로 교체
- `ShoppingView` / `PointView` / `SettingsView` placeholder 추가
- `AddressSearchView`: `MKMapItem.address` iOS 26+ API를 `@available`로 분기 처리
- `AddPlaceView`: `item.location.coordinate` → `item.placemark.location?.coordinate`로 교체
- `GeofenceManager` 위치 권한 흐름 수정 — `requestWhenInUseAuthorization` 추가, delegate에서 `.authorizedWhenInUse` 감지 시 `requestAlwaysAuthorization` 호출, init에서 기존 권한 상태 체크

## 💺 주요 코드 설명

### AppTab — enum 기반 탭 관리

```Swift
enum AppTab: String, CaseIterable, Hashable {
    case chore, shopping, point, settings
}

extension AppTab {
    var title: String { ... }
    var icon: String { ... }
}
```

- `CaseIterable`을 활용해 `ForEach(AppTab.allCases)`로 탭을 자동 렌더링한다.
- 탭 추가 시 enum case와 extension만 수정하면 된다.

### MainTabView — 탭별 NavigationPath 분리

```Swift
@State private var chorePath = NavigationPath()
@State private var shoppingPath = NavigationPath()

NavigationStack(path: $chorePath) {
    ChoreView()
}
```

- `NavigationPath`를 탭마다 따로 관리해 탭 전환 시 네비게이션 스택이 초기화되지 않도록 했다.
- `NavigationStack`은 각 탭의 루트에만 배치하고, 하위 뷰에서는 `navigationDestination`으로 이동한다.

### GeofenceManager — 위치 권한 2단계 흐름

```Swift
func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
    authorizationStatus = manager.authorizationStatus
    if manager.authorizationStatus == .authorizedWhenInUse {
        locationManager.requestAlwaysAuthorization()
    }
}
```

- iOS는 `notDetermined` → `authorizedWhenInUse` → `authorizedAlways` 순서를 강제한다.
- delegate에서 상태 변화를 감지해 자동으로 다음 단계 권한을 요청하도록 수정했다.
- 앱 재실행 시 delegate가 호출되지 않는 경우를 대비해 init에서도 상태를 체크한다.

## 🛤️ 구현화면

|   탭바 / 권한 설정   |  
| :----------: | 
| <img src = "https://github.com/user-attachments/assets/c5da7c25-91a8-4582-91fc-3d9675730081" width ="250" > | 
## 🚂 연결된 이슈



- Closes #26 

## 🚃 기타 더 이야기해볼 점

- `ShoppingView` / `PointView` / `SettingsView`는 현재 placeholder 상태로, 각 기능 이슈에서 구현 예정이다.
- `SettingsView` 내부에서 `PlacesListView`로 진입하는 네비게이션 연결은 Settings 구현 시 추가한다.
- `GeofenceManager` 권한 흐름 수정은 JAE-38 작업 중 발견한 사이드 픽스로, 실기기 테스트는 탭바 연결 후 진행 예정이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 탭 기반 네비게이션 시스템 도입으로 앱 구조가 개선되었습니다
  * 쇼핑, 포인트, 설정 등 새로운 기능이 추가되었습니다

* **개선 사항**
  * 주소 검색 기능이 다양한 iOS 버전에서 더욱 안정적으로 작동합니다
  * 위치 권한 요청 프로세스가 최적화되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->